### PR TITLE
groups: fixes path on group creation

### DIFF
--- a/src/api/groups.ts
+++ b/src/api/groups.ts
@@ -20,7 +20,7 @@ export default function(client: AxiosInstance) {
     },
 
     async createGroup(group: GroupData) {
-      return client.post('group', group)
+      return client.post('groups', group)
     },
 
     async updateGroup(groupId: number, groupUpdate: GroupData) {


### PR DESCRIPTION
Url path should be `/groups` instead of `/group` as described [here](https://developers.mailerlite.com/reference#create-group).