### PR TITLE
subscribers: fix function names typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,11 @@ Shorthand that resolves to a Promise<boolean>.
 
 #### `searchSubscribers(params?)`
 
-#### `getSubsscriberActivity(identifier)`
+#### `getSubscriberActivity(identifier)`
 
-#### `getSubsscriberActivityByType(identifier, activityType)`
+#### `getSubscriberActivityByType(identifier, activityType)`
 
-#### `getSubsscriberGroups(identifier)`
+#### `getSubscriberGroups(identifier)`
 
 ### Timezones
 

--- a/src/api/subscribers.ts
+++ b/src/api/subscribers.ts
@@ -23,7 +23,7 @@ export default function(client: AxiosInstance) {
       return client.get('subscribers/search', { params })
     },
 
-    async getSubsscriberActivity(identifier: number | string) {
+    async getSubscriberActivity(identifier: number | string) {
       return client.get(`subscribers/${identifier}/activity`)
     },
 
@@ -34,7 +34,7 @@ export default function(client: AxiosInstance) {
       return client.get(`subscribers/${identifier}/actvity/${activityType}`)
     },
 
-    async getSubsscriberGroups(identifier: number | string) {
+    async getSubscriberGroups(identifier: number | string) {
       return client.get(`subscribers/${identifier}/groups`)
     },
   }


### PR DESCRIPTION
Fixes typos in function name: `Subsscriber` -> `Subscriber`