### PR TITLE
Params missing in getGroupSubscribers

### DIFF
--- a/src/api/groups.ts
+++ b/src/api/groups.ts
@@ -72,7 +72,7 @@ export default function(client: AxiosInstance) {
     },
 
     async getGroupSubscribers(groupId: number, params: SubscriberGroupQuery = {}) {
-      return await client.get(`groups/${groupId}/subscribers`)
+      return await client.get(`groups/${groupId}/subscribers`, { params })
     },
 
     async getGroupSubscriberCount(groupId: number) {


### PR DESCRIPTION
After some time trying to understand why my custom paginate function wasn't working with getGroupSubscribers, I found that the _params_ param was missing in axios.get request. This PR fixes that.